### PR TITLE
Fixing generate_icons script and improving logging

### DIFF
--- a/generate_icons.sh
+++ b/generate_icons.sh
@@ -3,7 +3,7 @@
 icon_name="icon.png"
 output_path="icon.iconset"
 cd "$(dirname "${0}")" || exit
-rm -rf "$(output_path)/*" || true
+rm -rf "$(output_path)" || true
 mkdir -p "${output_path}"
 
 for size in 16 32 64 128 256 512 1024; do

--- a/generate_icons.sh
+++ b/generate_icons.sh
@@ -3,11 +3,12 @@
 icon_name="icon.png"
 output_path="icon.iconset"
 cd "$(dirname "${0}")" || exit
-rm -rf "output_path/*" || true
+rm -rf "$(output_path)/*" || true
+mkdir -p "${output_path}"
 
 for size in 16 32 64 128 256 512 1024; do
-  sips -z $size $size ${icon_name} --out "${output_path}/icon_${size}x${size}.png"
-  sips -z $size $size ${icon_name} --out "${output_path}/icon_${size}x${size}@2x.png"
+	sips -z $size $size ${icon_name} --out "${output_path}/icon_${size}x${size}.png"
+	sips -z $size $size ${icon_name} --out "${output_path}/icon_${size}x${size}@2x.png"
 done
 
 iconutil -c icns "${output_path}"

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"strconv"
@@ -43,7 +44,7 @@ func setLowPowerMode(str string) error {
 }
 
 func updateLowPowerStateMenu(hardwareUUID string) {
-	fmt.Println(hardwareUUID)
+	log.Printf("Hardware UUID is %s\n", hardwareUUID)
 	plistPath := fmt.Sprintf("/Library/Preferences/com.apple.PowerManagement.%s.plist", hardwareUUID)
 	currentState := ""
 
@@ -51,14 +52,14 @@ func updateLowPowerStateMenu(hardwareUUID string) {
 		cmd := exec.Command("defaults", "read", plistPath)
 		out, err := cmd.Output()
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+			log.Println(err)
 			continue
 		}
 
 		var config map[string]interface{}
 		_, err = plist.Unmarshal(out, &config)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+			log.Println(err)
 			continue
 		}
 
@@ -66,14 +67,14 @@ func updateLowPowerStateMenu(hardwareUUID string) {
 		batteryLowPowerModeStr := config["Battery Power"].(map[string]interface{})["LowPowerMode"].(string)
 		batteryLowPowerMode, err := strconv.ParseUint(batteryLowPowerModeStr, 10, 64)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+			log.Println(err)
 			continue
 		}
 
 		acLowPowerModeStr := config["AC Power"].(map[string]interface{})["LowPowerMode"].(string)
 		acLowPowerMode, err := strconv.ParseUint(acLowPowerModeStr, 10, 64)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
+			log.Println(err)
 			continue
 		}
 
@@ -90,7 +91,7 @@ func updateLowPowerStateMenu(hardwareUUID string) {
 		if state != currentState {
 			setMenuStatesFalse()
 			menuet.Defaults().SetBoolean(state, true)
-			fmt.Printf("updated state to %s\n", state)
+			log.Printf("Updated state from %s to %s\n", currentState, state)
 			currentState = state
 		}
 		time.Sleep(time.Second)
@@ -101,7 +102,7 @@ func updateCurrentState(currentIconState string) string {
 	cmd := exec.Command("pmset", "-g")
 	output, err := cmd.Output()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		log.Println(err)
 		return currentIconState
 	}
 


### PR DESCRIPTION
I was getting errors when trying to compile as it was creating the `icon.iconset` "folder" as a file. I've updated the script to what I think you wanted - but it all works on my end now.

I also reworked the logging to use the go native logging library. Looks a bit better and simplifies it.

New logging looks like this:
<img width="625" alt="image" src="https://github.com/TheDen/galvani/assets/22850972/3bc309d8-e915-4b8d-a75d-1374816ecf09">
